### PR TITLE
Fix indices of logvar_q in Multi-VAE

### DIFF
--- a/UserEmbedding/model/multivae.py
+++ b/UserEmbedding/model/multivae.py
@@ -147,7 +147,7 @@ class multiVAE:
         if self.using_trap == 0:
             self.U_Encoder = self.g_act(pre_Encoder)
             mu_q = self.U_Encoder[:, :self.U_hidden_neuron]
-            logvar_q = self.U_Encoder[:, :self.U_hidden_neuron]
+            logvar_q = self.U_Encoder[:, self.U_hidden_neuron:]
 
         else:
             self.g_act = tf.nn.tanh


### PR DESCRIPTION
The Multi-VAE without TRAP computes `logvar_q` incorrectly. It is the same as `mu_q`. This PR fixes this bug.